### PR TITLE
Add misc.xml to JetBrains.gitignore

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -5,6 +5,7 @@
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/dictionaries
+.idea/misc.xml
 
 # Sensitive or high-churn files:
 .idea/**/dataSources/


### PR DESCRIPTION
At least since Go support version 171.4694.61 IntelliJ has started to store a local path in misc.xml (component name="GOROOT") and can no longer be shared.
